### PR TITLE
fix(eslint): there should be a `.` after `Brion Mario`

### DIFF
--- a/.changeset/four-dragons-leave.md
+++ b/.changeset/four-dragons-leave.md
@@ -1,0 +1,5 @@
+---
+"@brionmario/eslint-plugin": patch
+---
+
+There should be a period `.` after `Brion Mario` in the copyright header.

--- a/packages/eslint-plugin/lib/configs/internal.js
+++ b/packages/eslint-plugin/lib/configs/internal.js
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2022, Brion Mario
+ * Copyright (c) 2022, Brion Mario.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -53,8 +53,8 @@ const getLicenseHeaderPattern = () => {
     ' * MIT License',
     ' *',
     {
-      pattern: ' Copyright \\(c\\) \\d{4}, Brion Mario',
-      template: ` * Copyright (c) ${new Date().getFullYear()}, Brion Mario`,
+      pattern: ' Copyright \\(c\\) \\d{4}, Brion Mario.',
+      template: ` * Copyright (c) ${new Date().getFullYear()}, Brion Mario.`,
     },
     ' *',
     ' * Permission is hereby granted, free of charge, to any person obtaining a copy',


### PR DESCRIPTION

"@brionmario/eslint-plugin": patch
---

There should be a period `.` after `Brion Mario` in the copyright header.