### PR TITLE
fix(eslint): bypass `no-restricted-exports` to allow `export {default} from` syntax

### DIFF
--- a/.changeset/pink-falcons-enjoy.md
+++ b/.changeset/pink-falcons-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@brionmario/eslint-plugin": patch
+---
+
+In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax. There's a tracker and a WIP PR to give first class support to bypass. Until then, I'm allowing `default` syntax. Config is copied from https://github.com/airbnb/javascript/blob/f3d3a07/packages/eslint-config-airbnb-base/rules/es6.js#L65.

--- a/packages/eslint-plugin/lib/configs/javascript.js
+++ b/packages/eslint-plugin/lib/configs/javascript.js
@@ -36,19 +36,22 @@ module.exports = {
     // If there are a mixture of export types, the imports will look ugly.
     // https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/docs/rules/prefer-default-export.md
     'import/prefer-default-export': 'off',
-    // Enforces sorting object properties in alphabetical order for readability.
-    // https://eslint.org/docs/latest/rules/sort-keys
-    'sort-keys': ['error', 'asc', {caseSensitive: true, minKeys: 2, natural: false}],
     // Disallow specified names in exports.
     // https://eslint.org/docs/rules/no-restricted-exports
     // FIXME: In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax.
-    // There's a tracker and a WIP PR to give first class support to bypass. Until then, I'm allowing `default` syntax.
+    // There's a tracker (https://github.com/eslint/eslint/issues/15617) and a WIP PR to give first class support to bypass.
+    // Until then, I'm allowing `default` syntax.
     // Config is copied from https://github.com/airbnb/javascript/blob/f3d3a07/packages/eslint-config-airbnb-base/rules/es6.js#L65.
-    'no-restricted-exports': ['error', {
-      restrictedNamedExports: [
-        'then', // this will cause tons of confusion when your module is dynamically `import()`ed, and will break in most node ESM versions
-      ],
-    }],
-    https://github.com/eslint/eslint/issues/15617
+    'no-restricted-exports': [
+      'error',
+      {
+        restrictedNamedExports: [
+          'then', // this will cause tons of confusion when your module is dynamically `import()`ed, and will break in most node ESM versions
+        ],
+      },
+    ],
+    // Enforces sorting object properties in alphabetical order for readability.
+    // https://eslint.org/docs/latest/rules/sort-keys
+    'sort-keys': ['error', 'asc', {caseSensitive: true, minKeys: 2, natural: false}],
   },
 };

--- a/packages/eslint-plugin/lib/configs/javascript.js
+++ b/packages/eslint-plugin/lib/configs/javascript.js
@@ -39,5 +39,16 @@ module.exports = {
     // Enforces sorting object properties in alphabetical order for readability.
     // https://eslint.org/docs/latest/rules/sort-keys
     'sort-keys': ['error', 'asc', {caseSensitive: true, minKeys: 2, natural: false}],
+    // Disallow specified names in exports.
+    // https://eslint.org/docs/rules/no-restricted-exports
+    // FIXME: In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax.
+    // There's a tracker and a WIP PR to give first class support to bypass. Until then, I'm allowing `default` syntax.
+    // Config is copied from https://github.com/airbnb/javascript/blob/f3d3a07/packages/eslint-config-airbnb-base/rules/es6.js#L65.
+    'no-restricted-exports': ['error', {
+      restrictedNamedExports: [
+        'then', // this will cause tons of confusion when your module is dynamically `import()`ed, and will break in most node ESM versions
+      ],
+    }],
+    https://github.com/eslint/eslint/issues/15617
   },
 };


### PR DESCRIPTION
---
"@brionmario/eslint-plugin": patch
---

In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax. There's a tracker and a WIP PR to give first class support to bypass. Until then, I'm allowing `default` syntax. Config is copied from https://github.com/airbnb/javascript/blob/f3d3a07/packages/eslint-config-airbnb-base/rules/es6.js#L65.