### PR TITLE
fix(eslint): bypass no-restricted-exports to allow `export {default} from` for TS

### DIFF
--- a/.changeset/afraid-humans-retire.md
+++ b/.changeset/afraid-humans-retire.md
@@ -1,0 +1,5 @@
+---
+"@brionmario/eslint-plugin": patch
+---
+
+`no-restricted-exports` rule was modified to allow `export {default} from` syntax in https://github.com/brionmario/ui-configs/pull/20. But, it's not working for TS files.

--- a/packages/eslint-plugin/lib/configs/typescript.js
+++ b/packages/eslint-plugin/lib/configs/typescript.js
@@ -64,5 +64,20 @@ module.exports = {
       rules: {},
     },
   ],
-  rules: {},
+  rules: {
+    // Disallow specified names in exports.
+    // https://eslint.org/docs/rules/no-restricted-exports
+    // FIXME: In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax.
+    // There's a tracker (https://github.com/eslint/eslint/issues/15617) and a WIP PR to give first class support to bypass.
+    // Until then, I'm allowing `default` syntax.
+    // Config is copied from https://github.com/airbnb/javascript/blob/f3d3a07/packages/eslint-config-airbnb-base/rules/es6.js#L65.
+    'no-restricted-exports': [
+      'error',
+      {
+        restrictedNamedExports: [
+          'then', // this will cause tons of confusion when your module is dynamically `import()`ed, and will break in most node ESM versions
+        ],
+      },
+    ],
+  },
 };


### PR DESCRIPTION
---
"@brionmario/eslint-plugin": patch
---

`no-restricted-exports` rule was modified to allow `export {default} from` syntax in https://github.com/brionmario/ui-configs/pull/20. But, it's not working for TS files.