### PR TITLE
fix(eslint): `no-restricted-exports` should go in overrides

### DIFF
--- a/.changeset/sixty-snakes-eat.md
+++ b/.changeset/sixty-snakes-eat.md
@@ -1,0 +1,5 @@
+---
+"@brionmario/eslint-plugin": patch
+---
+
+`no-restricted-exports` was put in first level `rules` hash in TS ruleset but it should go in overrides instead.

--- a/packages/eslint-plugin/lib/configs/typescript.js
+++ b/packages/eslint-plugin/lib/configs/typescript.js
@@ -61,23 +61,23 @@ module.exports = {
         warnOnUnsupportedTypeScriptVersion: true,
       },
       plugins: ['@typescript-eslint'],
-      rules: {},
-    },
-  ],
-  rules: {
-    // Disallow specified names in exports.
-    // https://eslint.org/docs/rules/no-restricted-exports
-    // FIXME: In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax.
-    // There's a tracker (https://github.com/eslint/eslint/issues/15617) and a WIP PR to give first class support to bypass.
-    // Until then, I'm allowing `default` syntax.
-    // Config is copied from https://github.com/airbnb/javascript/blob/f3d3a07/packages/eslint-config-airbnb-base/rules/es6.js#L65.
-    'no-restricted-exports': [
-      'error',
-      {
-        restrictedNamedExports: [
-          'then', // this will cause tons of confusion when your module is dynamically `import()`ed, and will break in most node ESM versions
+      rules: {
+        // Disallow specified names in exports.
+        // https://eslint.org/docs/rules/no-restricted-exports
+        // FIXME: In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax.
+        // There's a tracker (https://github.com/eslint/eslint/issues/15617) and a WIP PR to give first class support to bypass.
+        // Until then, I'm allowing `default` syntax.
+        // Config is copied from https://github.com/airbnb/javascript/blob/f3d3a07/packages/eslint-config-airbnb-base/rules/es6.js#L65.
+        'no-restricted-exports': [
+          'error',
+          {
+            restrictedNamedExports: [
+              'then', // this will cause tons of confusion when your module is dynamically `import()`ed, and will break in most node ESM versions
+            ],
+          },
         ],
       },
-    ],
-  },
+    },
+  ],
+  rules: {},
 };


### PR DESCRIPTION
---
"@brionmario/eslint-plugin": patch
---

`no-restricted-exports` was put in first level `rules` hash in TS ruleset but it should go in overrides instead.