### PR TITLE
fix(eslint): update `import/no-extraneous-dependencies` rule

### DIFF
--- a/.changeset/giant-papayas-provide.md
+++ b/.changeset/giant-papayas-provide.md
@@ -1,0 +1,5 @@
+---
+"@brionmario/eslint-plugin": patch
+---
+
+Update `import/no-extraneous-dependencies` rule

--- a/packages/eslint-plugin/lib/configs/javascript.js
+++ b/packages/eslint-plugin/lib/configs/javascript.js
@@ -31,11 +31,21 @@ module.exports = {
   rules: {
     // Harsh rule, Dev dependencies should to be used in test specs, configs, scripts and storybook files.
     // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md
-    'import/no-extraneous-dependencies': 'off',
-    // Bit harsh rule, some developers will like to have consistent exports in a module.
-    // If there are a mixture of export types, the imports will look ugly.
-    // https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/docs/rules/prefer-default-export.md
-    'import/prefer-default-export': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: [
+          '**/*.config.*cjs',
+          '**/scripts/*.js',
+          '**/*.stories.*',
+          '**/*.test.*',
+          '**/*.spec.*',
+          '**/__tests__/**',
+          '**/__mocks__/**',
+          'test-configs/**',
+        ],
+      },
+    ],
     // Disallow specified names in exports.
     // https://eslint.org/docs/rules/no-restricted-exports
     // FIXME: In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax.

--- a/packages/eslint-plugin/lib/configs/typescript.js
+++ b/packages/eslint-plugin/lib/configs/typescript.js
@@ -62,6 +62,23 @@ module.exports = {
       },
       plugins: ['@typescript-eslint'],
       rules: {
+        // Harsh rule, Dev dependencies should to be used in test specs, configs, scripts and storybook files.
+        // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md
+        'import/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: [
+              '**/*.config.*cjs',
+              '**/scripts/*.js',
+              '**/*.stories.*',
+              '**/*.test.*',
+              '**/*.spec.*',
+              '**/__tests__/**',
+              '**/__mocks__/**',
+              'test-configs/**',
+            ],
+          },
+        ],
         // Disallow specified names in exports.
         // https://eslint.org/docs/rules/no-restricted-exports
         // FIXME: In Airbnb ruleset, `default` is also restricted which disallows `export { default } from` syntax.


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose and scope of this pull request. -->
Dev dependencies should to be used in test specs, configs, scripts and storybook files.

## Changes Made

<!-- Describe the changes you have made in this pull request. Provide context for reviewers to understand the changes. -->
Update the rule.

```js
        'import/no-extraneous-dependencies': [
          'error',
          {
            devDependencies: [
              '**/*.config.*cjs',
              '**/scripts/*.js',
              '**/*.stories.*',
              '**/*.test.*',
              '**/*.spec.*',
              '**/__tests__/**',
              '**/__mocks__/**',
              'test-configs/**',
            ],
          },
        ],
```

## Related Issues

<!-- If this pull request is related to any GitHub issues mention them here.  Add `N/A` if there's nothing to mention. -->
- N/A

## Related Pull Requests

<!-- If this pull request is related to any other pull requests, mention them here. Add `N/A` if there's nothing to mention. -->

- N/A

## Screenshots (if applicable)

<!-- If your changes involve visual modifications, provide screenshots or GIFs to showcase the changes. Add `N/A` if there's nothing to mention. -->
- N/A

## Checklist

<!-- Mark the items that are applicable by replacing [ ] with [x]. -->

- [ ] I have tested these changes thoroughly.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have followed the coding style guidelines of the project.
- [ ] I have added suitable comments to the code, especially in complex areas.
- [ ] I have reviewed my own code to ensure there are no obvious errors.

## Additional Notes

<!-- Any additional notes or information that may be helpful for reviewers or future reference. Add `N/A` if there's nothing to mention. -->
- N/A