### PR TITLE
fix(eslint): remove `jest/no-jest-import`

### DIFF
--- a/.changeset/spicy-walls-rest.md
+++ b/.changeset/spicy-walls-rest.md
@@ -1,0 +1,5 @@
+---
+"@brionmario/eslint-plugin": patch
+---
+
+Remove `jest/no-jest-import`

--- a/packages/eslint-plugin/lib/configs/jest.js
+++ b/packages/eslint-plugin/lib/configs/jest.js
@@ -42,7 +42,6 @@ module.exports = {
         'jest/no-identical-title': 'error',
         'jest/no-interpolation-in-snapshots': 'error',
         'jest/no-jasmine-globals': 'error',
-        'jest/no-jest-import': 'error',
         'jest/no-mocks-import': 'error',
         'jest/valid-describe-callback': 'error',
         'jest/valid-expect': 'error',


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose and scope of this pull request. -->
Fix the error:

```js
 1:1  error  Definition for rule 'jest/no-jest-import' was not found  jest/no-jest-import
 ```

## Changes Made

<!-- Describe the changes you have made in this pull request. Provide context for reviewers to understand the changes. -->
Remove the `jest/no-jest-import` rule since it's removed.

## Related Issues

<!-- If this pull request is related to any GitHub issues mention them here.  Add `N/A` if there's nothing to mention. -->
- N/A

## Related Pull Requests

<!-- If this pull request is related to any other pull requests, mention them here. Add `N/A` if there's nothing to mention. -->

- N/A

## Screenshots (if applicable)

<!-- If your changes involve visual modifications, provide screenshots or GIFs to showcase the changes. Add `N/A` if there's nothing to mention. -->
- N/A

## Checklist

<!-- Mark the items that are applicable by replacing [ ] with [x]. -->

- [ ] I have tested these changes thoroughly.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have followed the coding style guidelines of the project.
- [ ] I have added suitable comments to the code, especially in complex areas.
- [ ] I have reviewed my own code to ensure there are no obvious errors.

## Additional Notes

<!-- Any additional notes or information that may be helpful for reviewers or future reference. Add `N/A` if there's nothing to mention. -->
- N/A