### PR TITLE
fix(eslint): update `import/no-extraneous-dependencies` glob pattern

### DIFF
--- a/.changeset/brave-seas-eat.md
+++ b/.changeset/brave-seas-eat.md
@@ -1,0 +1,22 @@
+---
+"@brionmario/eslint-plugin": patch
+---
+
+Update no-extraneous glob:
+
+```js
+'import/no-extraneous-dependencies': [
+  'error',
+  {
+    devDependencies: [
+      '**/*.config.*', // Match config files in JS, TS, CJS, and MJS
+      '**/scripts/*.{js,ts,cjs,mjs}', // Match script files in JS and TS
+      '**/*.stories.*', // Storybook files
+      '**/*.test.*', // Test files in JS and TS
+      '**/*.spec.*', // Spec files in JS and TS
+      '**/__tests__/**', // Test directories
+      '**/__mocks__/**', // Mock directories
+      'test-configs/**', // Test configuration files
+    ],
+  },
+```

--- a/packages/eslint-plugin/lib/configs/javascript.js
+++ b/packages/eslint-plugin/lib/configs/javascript.js
@@ -35,14 +35,14 @@ module.exports = {
       'error',
       {
         devDependencies: [
-          '**/*.config.*cjs',
-          '**/scripts/*.js',
-          '**/*.stories.*',
-          '**/*.test.*',
-          '**/*.spec.*',
-          '**/__tests__/**',
-          '**/__mocks__/**',
-          'test-configs/**',
+          '**/*.config.*', // Match config files in JS, TS, CJS, and MJS
+          '**/scripts/*.{js,ts,cjs,mjs}', // Match script files in JS and TS
+          '**/*.stories.*', // Storybook files
+          '**/*.test.*', // Test files in JS and TS
+          '**/*.spec.*', // Spec files in JS and TS
+          '**/__tests__/**', // Test directories
+          '**/__mocks__/**', // Mock directories
+          'test-configs/**', // Test configuration files
         ],
       },
     ],


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose and scope of this pull request. -->

`import/no-extraneous-dependencies` glob pattern were not allowing certain config files like `.js` etc.
 
## Changes Made

<!-- Describe the changes you have made in this pull request. Provide context for reviewers to understand the changes. -->

Update no-extraneous glob:

```js
'import/no-extraneous-dependencies': [
  'error',
  {
    devDependencies: [
      '**/*.config.*', // Match config files in JS, TS, CJS, and MJS
      '**/scripts/*.{js,ts,cjs,mjs}', // Match script files in JS and TS
      '**/*.stories.*', // Storybook files
      '**/*.test.*', // Test files in JS and TS
      '**/*.spec.*', // Spec files in JS and TS
      '**/__tests__/**', // Test directories
      '**/__mocks__/**', // Mock directories
      'test-configs/**', // Test configuration files
    ],
  },
```

## Related Issues

<!-- If this pull request is related to any GitHub issues mention them here.  Add `N/A` if there's nothing to mention. -->
N/A

## Related Pull Requests

<!-- If this pull request is related to any other pull requests, mention them here. Add `N/A` if there's nothing to mention. -->

N/A

## Screenshots (if applicable)

<!-- If your changes involve visual modifications, provide screenshots or GIFs to showcase the changes. Add `N/A` if there's nothing to mention. -->
N/A

## Checklist

<!-- Mark the items that are applicable by replacing [ ] with [x]. -->

- [ ] I have tested these changes thoroughly.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have followed the coding style guidelines of the project.
- [ ] I have added suitable comments to the code, especially in complex areas.
- [ ] I have reviewed my own code to ensure there are no obvious errors.

## Additional Notes

<!-- Any additional notes or information that may be helpful for reviewers or future reference. Add `N/A` if there's nothing to mention. -->
N/A
